### PR TITLE
Display Elapsed Time Waiting

### DIFF
--- a/assets/templates/waitlist.html.tmpl
+++ b/assets/templates/waitlist.html.tmpl
@@ -176,24 +176,28 @@
      <tr>
        <th>Party Name</th>
        <th>Party Size</th>
-       <th>Minutes Waiting</th>
+       <th>Time Spent Waiting</th>
        <th>Type</th>
        <th>Actions</th>
    </tr>
 </thead>
 <tbody>
   {{range .waitlist_data}}
-           <tr>
-             <td>{{.PartyName}}</td>
-             <td>{{.PartySize}}</td>
-             <td>{{.WaitTimeExpected}}</td>
-             <td>{{.PhoneAhead}}</td>
-             <td>
-               <button type="button" onclick="alert('Something!')">Click Me!</button>
-               <button type="button" onclick="alert('Delete!')">Delete</button>
-             </td>
-           </tr>
-         {{end}}
+          <tr>
+            <td>{{.PartyName}}</td>
+            <td>{{.PartySize}}</td>
+            <td>{{ (call $.formatElapsedWaitingTime .TimeCreated) }}</td>
+            {{ if .PhoneAhead }}
+              <td><span class="glyphicon glyphicon-earphone"></span></td>
+            {{else}}
+              <td><span class="glyphicon glyphicon-user"></span></td>
+            {{end}}
+            <td>
+              <button type="button" onclick="alert('Something!')">Click Me!</button>
+              <button type="button" onclick="alert('Delete!')">Delete</button>
+            </td>
+          </tr>
+        {{end}}
 </tbody>
 </table>
 </div>

--- a/url_handlers.go
+++ b/url_handlers.go
@@ -11,6 +11,8 @@ import (
     "math/rand"
     "time"
     "io/ioutil"
+    "fmt"
+    "math"
     _ "github.com/jinzhu/gorm/dialects/postgres"
   )
 
@@ -109,13 +111,19 @@ func WaitListHandler(w http.ResponseWriter, r *http.Request) {
   }
 
   var parties []ActiveParty
-  db.Find(&parties)
+  db.Order("time_created asc").Find(&parties)
 
-  party_data := map[string]interface{}{}
-  party_data["waitlist_data"] = parties
-
-
-  RenderTemplate(w, "assets/templates/waitlist.html.tmpl", party_data)
+  partyData := map[string]interface{}{}
+  partyData["waitlist_data"] = parties
+  //This function is called by the template to format the time an ActiveParty was created it in
+  //HH:MM form.
+  partyData["formatElapsedWaitingTime"] = func (partyCreatedTime time.Time) string {
+    duration := time.Now().Sub(partyCreatedTime)
+    hours := math.Floor(duration.Hours())
+    minutes := math.Floor((duration.Hours()-hours)*60)
+    return fmt.Sprintf("%02d:%02d", int(hours), int(minutes))
+  }
+  RenderTemplate(w, "assets/templates/waitlist.html.tmpl", partyData)
 }
 
 func RootHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Updated the frontend/backend to display the time an active party has been waiting instead of the estimated wait time.

Also changed the ActiveParties query by time_created to sort by `time_created` so that the party that has been waiting the longest is first in the list.

Display the phone ahead/in person glyphicons in the table.