### PR TITLE
Change buzzer activeness to inactive when deleting an active party if…

### DIFF
--- a/assets/static/js/buzzer.js
+++ b/assets/static/js/buzzer.js
@@ -13,7 +13,7 @@ function AjaxJSONPOST(url, jsonStr, errorCallback, successCallback, completeCall
 }
 
 function errorAlert(errorStr) {
-  $('#alert_placeholder').html('<div class="alert alert-danger alert_place" role="alert">'+errorStr+'/div>');
+  $('#alert_placeholder').html('<div class="alert alert-danger alert_place" role="alert">'+errorStr+'</div>');
 }
 
 function addPartyErrorCallback(xhr, error) {

--- a/url_handlers.go
+++ b/url_handlers.go
@@ -221,6 +221,15 @@ func GetBuzzerObjFromName(reqBodyObj map[string] interface{}, responseObj map[st
   return true
 }
 
+func GetBuzzerObjFromID(buzzerID int, responseObj map[string] interface{}, buzzer *Buzzer) bool {
+  db.First(buzzer, "id = ?", buzzerID)
+  if *buzzer == (Buzzer{}) {
+    AddErrorMessageToResponseObj(responseObj, "Buzzer with that ID not found.")
+    return false
+  }
+  return true
+}
+
 func GetActivePartyFromBuzzerID(responseObj map[string] interface{}, buzzer Buzzer, activeParty *ActiveParty) bool {
   db.First(activeParty, "buzzer_id = ?", buzzer.ID)
   if *activeParty == (ActiveParty{}) {
@@ -321,6 +330,7 @@ func IsBuzzerRegisteredHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteActivePartyHandler deletes the specificed active party ID
+//TODO: Move the active parties into historical parties.
 func DeleteActivePartyHandler(w http.ResponseWriter, r *http.Request) {
     log.SetPrefix("[DeleteActivePartyHandler] ")
     responseObj := map[string] interface{} {}
@@ -334,15 +344,25 @@ func DeleteActivePartyHandler(w http.ResponseWriter, r *http.Request) {
             responseObj["status"] = "failure"
             responseObj["error_message"] = "Missing active_party_id parameter"
         } else {
-            var activeparty ActiveParty
-            db.First(&activeparty, "ID=?", activePartyID)
-            dbInfo := db.Delete(&activeparty)
-
-            if dbInfo.Error == nil {
-                responseObj["status"] = "success"
-            } else {
-                responseObj["status"] = "failure"
-                responseObj["error_message"] = "db.Delete failed"
+            var activeParty ActiveParty
+            db.First(&activeParty, "ID=?", activePartyID)
+            failedBuzzerUpdate := false
+            if (activeParty.BuzzerID != 0) {
+              var buzzer Buzzer
+              if GetBuzzerObjFromID(activeParty.BuzzerID, responseObj, &buzzer) {
+                db.Model(&buzzer).Update("is_active", false)
+              } else {
+                failedBuzzerUpdate = true
+              }
+            }
+            if !failedBuzzerUpdate {
+              dbInfo := db.Delete(&activeParty)
+              if dbInfo.Error == nil {
+                  responseObj["status"] = "success"
+              } else {
+                  responseObj["status"] = "failure"
+                  responseObj["error_message"] = "db.Delete failed"
+              }
             }
         }
     }


### PR DESCRIPTION
… there is a buzzer associated with the party

In the future active parties with no buzzer assigned to them will be just phone aheads but for now because the add party flow doesn't wait for a buzzer to be assigned to a new party, there may be parties that should have a buzzer assigned to them that don't.