### PR TITLE
Fix Add Party Formatting

### DIFF
--- a/assets/static/css/buzzer.css
+++ b/assets/static/css/buzzer.css
@@ -58,10 +58,6 @@ body {
     color: #FFFFFF;
 }
 
-#party-dropdown {
-  /*margin-left: 20px;*/
-}
-
 /* Center the login elements */
 .login {
     /* Horizontal */

--- a/assets/static/css/buzzer.css
+++ b/assets/static/css/buzzer.css
@@ -60,6 +60,10 @@ body {
     color: #FFFFFF;
 }
 
+#party-dropdown {
+  /*margin-left: 20px;*/
+}
+
 /* Center the login elements */
 .login {
     /* Horizontal */
@@ -157,6 +161,12 @@ body {
     border-color: white;
 }
 
+#hours-dropdown {
+  margin-left: 10px;
+}
+
+
+
 .login-alert {
     /* Horizontal */
     display: block;
@@ -171,11 +181,27 @@ body {
     transform: translateY(25%);
 }
 
-/*.img-responsive{
-    width:5%;
-    height:5%;
+.add-party-justify {
+  margin-top: 10px;
+  text-align: center;
 }
-*/
+
+.add-party-button {
+  margin-left: 10px;
+}
+
+.add-party-container {
+  margin-top: 25px;
+  margin-bottom: 25px;
+}
+
+@media (min-width: 991px){
+  .add-party-justify {
+    margin-top: 0px;
+    text-align: right;
+  }
+}
+
 .alert-danger {
     color: #FFFFFF;
     background-color: #DD2A17;

--- a/assets/static/js/buzzer.js
+++ b/assets/static/js/buzzer.js
@@ -104,7 +104,7 @@ $(document).ready(function() {
   $(".add-party-button").click(function(){
     // activePartyID = $('#party-name-field').id();
     partyName = $('#party-name-field').val();
-    partySize = $('.btn#party-dropdown').val();
+    partySize = $('.btn#party-dropdown-button').val();
     waitHours = $('.btn#hours-dropdown').val();
     waitMins = $('.btn#minutes-dropdown').val();
     phoneAhead = $('.phone-ahead-toggle .active input').attr('id') === "phone" ? true : false;
@@ -129,9 +129,11 @@ $(document).ready(function() {
   registerDeletePartyClickHandlers();
   registerBuzzClickHandlers();
 
-  $(".dropdown-menu li a").click(function(){
+  $(".party-dropdown li a").click(function(){
     console.log("in handler");
-    $(this).parents(".dropdown").find('.btn').html($(this).text() + ' <span class="caret"></span>');
-    $(this).parents(".dropdown").find('.btn').val($(this).text());
+    console.log($(this).text())
+
+    $(this).parents(".party-dropdown").find('.btn').html($(this).text() + ' <span class="caret"></span>');
+    $(this).parents(".party-dropdown").find('.btn').val($(this).text());
   });
 });

--- a/assets/static/js/buzzer.js
+++ b/assets/static/js/buzzer.js
@@ -129,11 +129,11 @@ $(document).ready(function() {
   registerDeletePartyClickHandlers();
   registerBuzzClickHandlers();
 
-  $(".party-dropdown li a").click(function(){
+  $(".dropdown li a").click(function(){
     console.log("in handler");
     console.log($(this).text())
 
-    $(this).parents(".party-dropdown").find('.btn').html($(this).text() + ' <span class="caret"></span>');
-    $(this).parents(".party-dropdown").find('.btn').val($(this).text());
+    $(this).parents(".dropdown").find('.btn').html($(this).text() + ' <span class="caret"></span>');
+    $(this).parents(".dropdown").find('.btn').val($(this).text());
   });
 });

--- a/assets/static/js/buzzer.js
+++ b/assets/static/js/buzzer.js
@@ -132,8 +132,6 @@ $(document).ready(function() {
 
   $(".dropdown li a").click(function(){
     console.log("in handler");
-    console.log($(this).text())
-
     $(this).parents(".dropdown").find('.btn').html($(this).text() + ' <span class="caret"></span>');
     $(this).parents(".dropdown").find('.btn').val($(this).text());
   });

--- a/assets/templates/waitlist.html.tmpl
+++ b/assets/templates/waitlist.html.tmpl
@@ -85,7 +85,7 @@
         <div class="col-md-4 col-md-offset-2" align="center">
           <div class="input-group">
             <input type="text" class="form-control" id="party-name-field" placeholder="Party Name"></input>
-              <span class="input-group-btn party-dropdown">
+              <span class="input-group-btn dropdown">
                 <button class="btn btn-default dropdown-toggle" type="button" id="party-dropdown-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true", value = "">
                   Party Size <span class="caret"></span>
                 </button>
@@ -105,9 +105,9 @@
                 </ul>
               </span>
           </div>
-
         </div>
 
+        <!-- Rest of Add party stuff. Expected Wait time, phone ahead/in person selection, add button. -->
         <div class="col-md-4 add-party-justify">
           <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
             <label class="btn btn-default active" id="btnrocker">
@@ -151,121 +151,12 @@
           <button class="btn btn-default add-party-button" type="button">ADD</button>
         </div>
 
-        <!-- <div class="col-md-3" align="center">
-          <div class="btn-group dropdown">
-            <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
-              Hours <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu">
-              <li><a href="#">0</a></li>
-              <li><a href="#">1</a></li>
-              <li><a href="#">2</a></li>
-              <li><a href="#">3</a></li>
-            </ul>
-          </div>
-          <strong>:</strong>
-          <div class="btn-group dropdown">
-            <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
-              Minutes <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu">
-               <li><a href="#">00</a></li>
-               <li><a href="#">05</a></li>
-               <li><a href="#">10</a></li>
-               <li><a href="#">15</a></li>
-               <li><a href="#">20</a></li>
-               <li><a href="#">25</a></li>
-               <li><a href="#">30</a></li>
-               <li><a href="#">35</a></li>
-               <li><a href="#">40</a></li>
-               <li><a href="#">45</a></li>
-               <li><a href="#">50</a></li>
-               <li><a href="#">55</a></li>
-             </ul>
-          </div>
-        </div> -->
-
-        <!-- <div class="col-md-3" align="center">
-
-        </div> -->
-
-
       </div>
     </div>
   </div>
-<!-- </div> -->
-                <!-- <div class="col/-md-3 text-center">
-                  <div class="dropdown">
-
-                    <ul class="dropdown-menu">
-                        <li><a href="#">1</a></li>
-                        <li><a href="#">2</a></li>
-                        <li><a href="#">3</a></li>
-                        <li><a href="#">4</a></li>
-                        <li><a href="#">5</a></li>
-                        <li><a href="#">6</a></li>
-                        <li><a href="#">7</a></li>
-                        <li><a href="#">8</a></li>
-                        <li><a href="#">9</a></li>
-                        <li><a href="#">10</a></li>
-                        <li><a href="#">11</a></li>
-                        <li><a href="#">12</a></li>
-                    </ul>
-                    </div>
-                </div>
-                <div class="col-md-3 text-center">
-                  <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
-                    <label class="btn btn-default active" id="btnrocker">
-                        <input type="radio" name="options" id="waitlist" width="20"><span class="glyphicon glyphicon-user"></span>
-                    </label>
-                    <label class="btn btn-default" id="btnrocker">
-                        <input type="radio" name="options" id="phone" width="20"><span class="glyphicon glyphicon-earphone"></span>
-                    </label>
-                  </div>
-                </div>
-                <div class="col-md-3 text-center">
-                  <div class="btn-group dropdown">
-                    <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
-                      Hours <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                      <li><a href="#">0</a></li>
-                      <li><a href="#">1</a></li>
-                      <li><a href="#">2</a></li>
-                      <li><a href="#">3</a></li>
-                    </ul>
-                  </div>
-                  <strong>:</strong>
-                  <div class="btn-group dropdown">
-                    <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
-                      Minutes <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                       <li><a href="#">00</a></li>
-                       <li><a href="#">05</a></li>
-                       <li><a href="#">10</a></li>
-                       <li><a href="#">15</a></li>
-                       <li><a href="#">20</a></li>
-                       <li><a href="#">25</a></li>
-                       <li><a href="#">30</a></li>
-                       <li><a href="#">35</a></li>
-                       <li><a href="#">40</a></li>
-                       <li><a href="#">45</a></li>
-                       <li><a href="#">50</a></li>
-                       <li><a href="#">55</a></li>
-                     </ul>
-                  </div>
-                  <button class="btn btn-default add-party-button" type="button">ADD</button>
-                  </div>
-                </div>
-            </div>
-        </div>
-    </div>
-  </div>
-</div> -->
 
 <!-- Responsive Table used from: http://www.w3schools.com/bootstrap/bootstrap_tables.asp -->
-<div class="row">
+  <div class="row">
     <div class="col-md-12">
      <h2>Waitlist</h2>
      <table class="table table-bordered" id="waitlist-table">
@@ -273,7 +164,6 @@
          <tr>
            <th>Party Name</th>
            <th>Party Size</th>
-
            <th>Time Spent Waiting</th>
            <th>Type</th>
            <th>Actions</th>
@@ -299,8 +189,7 @@
     </tbody>
     </table>
     </div>
-</div>
-
+  </div>
 </div>
 </body>
 </html>

--- a/assets/templates/waitlist.html.tmpl
+++ b/assets/templates/waitlist.html.tmpl
@@ -78,112 +78,229 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-3 col-sm-3">
-      <input type="text" class="form-control" id="party-name-field" placeholder="Party Name">
-    </div>
-    <div class="col-md-2 col-sm-3">
-      <div class="dropdown">
-        <button class="btn btn-default dropdown-toggle" type="button" id="party-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true", value = "">
-          Party Size <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-            <li><a href="#">1</a></li>
-            <li><a href="#">2</a></li>
-            <li><a href="#">3</a></li>
-            <li><a href="#">4</a></li>
-            <li><a href="#">5</a></li>
-            <li><a href="#">6</a></li>
-            <li><a href="#">7</a></li>
-            <li><a href="#">8</a></li>
-            <li><a href="#">9</a></li>
-            <li><a href="#">10</a></li>
-            <li><a href="#">11</a></li>
-            <li><a href="#">12</a></li>
-        </ul>
+    <div class="col-md-12 add-party-container">
+      <div class="row">
+
+        <!-- Party Name/Party Size button grouping -->
+        <div class="col-md-4 col-md-offset-2" align="center">
+          <div class="input-group">
+            <input type="text" class="form-control" id="party-name-field" placeholder="Party Name"></input>
+              <span class="input-group-btn party-dropdown">
+                <button class="btn btn-default dropdown-toggle" type="button" id="party-dropdown-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true", value = "">
+                  Party Size <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li><a href="#">1</a></li>
+                  <li><a href="#">2</a></li>
+                  <li><a href="#">3</a></li>
+                  <li><a href="#">4</a></li>
+                  <li><a href="#">5</a></li>
+                  <li><a href="#">6</a></li>
+                  <li><a href="#">7</a></li>
+                  <li><a href="#">8</a></li>
+                  <li><a href="#">9</a></li>
+                  <li><a href="#">10</a></li>
+                  <li><a href="#">11</a></li>
+                  <li><a href="#">12</a></li>
+                </ul>
+              </span>
+          </div>
+
         </div>
-    </div>
-    <!-- Source: http://stackoverflow.com/questions/22362750/bootstrap-button-group-pre-select-button-with-html-only: -->
-    <div class="col-md-3 col-sm-3">
-      <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
-        <label class="btn btn-default active" id="btnrocker">
-            <input type="radio" name="options" id="waitlist" width="20"><span class="glyphicon glyphicon-user"></span>
-        </label>
-        <label class="btn btn-default" id="btnrocker">
-            <input type="radio" name="options" id="phone" width="20"><span class="glyphicon glyphicon-earphone"></span>
-        </label>
+
+        <div class="col-md-4 add-party-justify">
+          <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
+            <label class="btn btn-default active" id="btnrocker">
+                <input type="radio" name="options" id="waitlist" width="20"><span class="glyphicon glyphicon-user"></span>
+            </label>
+            <label class="btn btn-default" id="btnrocker">
+                <input type="radio" name="options" id="phone" width="20"><span class="glyphicon glyphicon-earphone"></span>
+            </label>
+          </div>
+          <div class="btn-group dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
+              Hours <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="#">0</a></li>
+              <li><a href="#">1</a></li>
+              <li><a href="#">2</a></li>
+              <li><a href="#">3</a></li>
+            </ul>
+          </div>
+          <strong>:</strong>
+          <div class="btn-group dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
+              Minutes <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+               <li><a href="#">00</a></li>
+               <li><a href="#">05</a></li>
+               <li><a href="#">10</a></li>
+               <li><a href="#">15</a></li>
+               <li><a href="#">20</a></li>
+               <li><a href="#">25</a></li>
+               <li><a href="#">30</a></li>
+               <li><a href="#">35</a></li>
+               <li><a href="#">40</a></li>
+               <li><a href="#">45</a></li>
+               <li><a href="#">50</a></li>
+               <li><a href="#">55</a></li>
+             </ul>
+          </div>
+          <button class="btn btn-default add-party-button" type="button">ADD</button>
+        </div>
+
+        <!-- <div class="col-md-3" align="center">
+          <div class="btn-group dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
+              Hours <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="#">0</a></li>
+              <li><a href="#">1</a></li>
+              <li><a href="#">2</a></li>
+              <li><a href="#">3</a></li>
+            </ul>
+          </div>
+          <strong>:</strong>
+          <div class="btn-group dropdown">
+            <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
+              Minutes <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+               <li><a href="#">00</a></li>
+               <li><a href="#">05</a></li>
+               <li><a href="#">10</a></li>
+               <li><a href="#">15</a></li>
+               <li><a href="#">20</a></li>
+               <li><a href="#">25</a></li>
+               <li><a href="#">30</a></li>
+               <li><a href="#">35</a></li>
+               <li><a href="#">40</a></li>
+               <li><a href="#">45</a></li>
+               <li><a href="#">50</a></li>
+               <li><a href="#">55</a></li>
+             </ul>
+          </div>
+        </div> -->
+
+        <!-- <div class="col-md-3" align="center">
+
+        </div> -->
+
+
       </div>
-    </div>
-    <div class="col-md-4 col-sm-3">
-      <div class="btn-group dropdown">
-        <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
-          Hours <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li><a href="#">0</a></li>
-          <li><a href="#">1</a></li>
-          <li><a href="#">2</a></li>
-          <li><a href="#">3</a></li>
-        </ul>
-      </div>
-      <strong>:</strong>
-      <div class="btn-group dropdown">
-        <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
-          Minutes <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-           <li><a href="#">00</a></li>
-           <li><a href="#">05</a></li>
-           <li><a href="#">10</a></li>
-           <li><a href="#">15</a></li>
-           <li><a href="#">20</a></li>
-           <li><a href="#">25</a></li>
-           <li><a href="#">30</a></li>
-           <li><a href="#">35</a></li>
-           <li><a href="#">40</a></li>
-           <li><a href="#">45</a></li>
-           <li><a href="#">50</a></li>
-           <li><a href="#">55</a></li>
-         </ul>
-      </div>
-      <button class="btn btn-default add-party-button" type="button">ADD</button>
     </div>
   </div>
-</div>
+<!-- </div> -->
+                <!-- <div class="col/-md-3 text-center">
+                  <div class="dropdown">
+
+                    <ul class="dropdown-menu">
+                        <li><a href="#">1</a></li>
+                        <li><a href="#">2</a></li>
+                        <li><a href="#">3</a></li>
+                        <li><a href="#">4</a></li>
+                        <li><a href="#">5</a></li>
+                        <li><a href="#">6</a></li>
+                        <li><a href="#">7</a></li>
+                        <li><a href="#">8</a></li>
+                        <li><a href="#">9</a></li>
+                        <li><a href="#">10</a></li>
+                        <li><a href="#">11</a></li>
+                        <li><a href="#">12</a></li>
+                    </ul>
+                    </div>
+                </div>
+                <div class="col-md-3 text-center">
+                  <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
+                    <label class="btn btn-default active" id="btnrocker">
+                        <input type="radio" name="options" id="waitlist" width="20"><span class="glyphicon glyphicon-user"></span>
+                    </label>
+                    <label class="btn btn-default" id="btnrocker">
+                        <input type="radio" name="options" id="phone" width="20"><span class="glyphicon glyphicon-earphone"></span>
+                    </label>
+                  </div>
+                </div>
+                <div class="col-md-3 text-center">
+                  <div class="btn-group dropdown">
+                    <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
+                      Hours <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                      <li><a href="#">0</a></li>
+                      <li><a href="#">1</a></li>
+                      <li><a href="#">2</a></li>
+                      <li><a href="#">3</a></li>
+                    </ul>
+                  </div>
+                  <strong>:</strong>
+                  <div class="btn-group dropdown">
+                    <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
+                      Minutes <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                       <li><a href="#">00</a></li>
+                       <li><a href="#">05</a></li>
+                       <li><a href="#">10</a></li>
+                       <li><a href="#">15</a></li>
+                       <li><a href="#">20</a></li>
+                       <li><a href="#">25</a></li>
+                       <li><a href="#">30</a></li>
+                       <li><a href="#">35</a></li>
+                       <li><a href="#">40</a></li>
+                       <li><a href="#">45</a></li>
+                       <li><a href="#">50</a></li>
+                       <li><a href="#">55</a></li>
+                     </ul>
+                  </div>
+                  <button class="btn btn-default add-party-button" type="button">ADD</button>
+                  </div>
+                </div>
+            </div>
+        </div>
+    </div>
+  </div>
+</div> -->
 
 <!-- Responsive Table used from: http://www.w3schools.com/bootstrap/bootstrap_tables.asp -->
-<div class="container">
- <h2>Waitlist</h2>
- <table class="table table-bordered" id="waitlist-table">
-   <thead>
-     <tr>
-       <th>Party Name</th>
-       <th>Party Size</th>
+<div class="row">
+    <div class="col-md-12">
+     <h2>Waitlist</h2>
+     <table class="table table-bordered" id="waitlist-table">
+       <thead>
+         <tr>
+           <th>Party Name</th>
+           <th>Party Size</th>
 
-       <th>Time Spent Waiting</th>
-       <th>Type</th>
-       <th>Actions</th>
-   </tr>
-</thead>
-<tbody>
-  {{range .waitlist_data}}
-    <tr activePartyID="{{.ID}}">
-      <td>{{.PartyName}}</td>
-      <td>{{.PartySize}}</td>
-      <td>{{ (call $.formatElapsedWaitingTime .TimeCreated) }}</td>
-      {{ if .PhoneAhead }}
-        <td><span class="glyphicon glyphicon-earphone"></span></td>
-      {{else}}
-        <td><span class="glyphicon glyphicon-user"></span></td>
+           <th>Time Spent Waiting</th>
+           <th>Type</th>
+           <th>Actions</th>
+       </tr>
+    </thead>
+    <tbody>
+      {{range .waitlist_data}}
+        <tr activePartyID="{{.ID}}">
+          <td>{{.PartyName}}</td>
+          <td>{{.PartySize}}</td>
+          <td>{{ (call $.formatElapsedWaitingTime .TimeCreated) }}</td>
+          {{ if .PhoneAhead }}
+            <td><span class="glyphicon glyphicon-earphone"></span></td>
+          {{else}}
+            <td><span class="glyphicon glyphicon-user"></span></td>
+          {{end}}
+          <td>
+            <button class="btn btn-default buzz-button" type="button">Buzz!</button>
+            <button class="btn btn-default delete-party-button" type="button">Delete</button>
+          </td>
+        </tr>
       {{end}}
-      <td>
-        <button class="btn btn-default buzz-button" type="button">Buzz!</button>
-        <button class="btn btn-default delete-party-button" type="button">Delete</button>
-      </td>
-    </tr>
-  {{end}}
-</tbody>
-</table>
+    </tbody>
+    </table>
+    </div>
 </div>
 
+</div>
 </body>
 </html>

--- a/assets/templates/waitlist.html.tmpl
+++ b/assets/templates/waitlist.html.tmpl
@@ -72,94 +72,82 @@
 </div>
 </nav>
 
-
-<!-- Should remove this and overhaul header-->
-<!-- <br>
-<br>
-<br> -->
 <div class="row login-alert">
   <div id="alert_placeholder"></div>
 </div>
-<!-- <br> -->
 
-<div class="container-fluid">
- <div class="row">
-   <div class="col-md-3 col-sm-3">
-     <input type="text" class="form-control" id="party-name-field" placeholder="Party Name">
- </div>
- <div class="col-md-2 col-sm-3">
-  <div class="dropdown">
-    <button class="btn btn-default dropdown-toggle" type="button" id="party-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true", value = "">
-      Party Size <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-      <li><a href="#">1</a></li>
-      <li><a href="#">2</a></li>
-      <li><a href="#">3</a></li>
-      <li><a href="#">4</a></li>
-      <li><a href="#">5</a></li>
-      <li><a href="#">6</a></li>
-      <li><a href="#">7</a></li>
-      <li><a href="#">8</a></li>
-      <li><a href="#">9</a></li>
-      <li><a href="#">10</a></li>
-      <li><a href="#">11</a></li>
-      <li><a href="#">12</a></li>
-  </ul>
-
-</div>
-</div>
-
-<!-- Source: http://stackoverflow.com/questions/22362750/bootstrap-button-group-pre-select-button-with-html-only: -->
-<div class="col-md-3 col-sm-3">
-    <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
+<div class="container">
+  <div class="row">
+    <div class="col-md-3 col-sm-3">
+      <input type="text" class="form-control" id="party-name-field" placeholder="Party Name">
+    </div>
+    <div class="col-md-2 col-sm-3">
+      <div class="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button" id="party-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true", value = "">
+          Party Size <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+            <li><a href="#">1</a></li>
+            <li><a href="#">2</a></li>
+            <li><a href="#">3</a></li>
+            <li><a href="#">4</a></li>
+            <li><a href="#">5</a></li>
+            <li><a href="#">6</a></li>
+            <li><a href="#">7</a></li>
+            <li><a href="#">8</a></li>
+            <li><a href="#">9</a></li>
+            <li><a href="#">10</a></li>
+            <li><a href="#">11</a></li>
+            <li><a href="#">12</a></li>
+        </ul>
+        </div>
+    </div>
+    <!-- Source: http://stackoverflow.com/questions/22362750/bootstrap-button-group-pre-select-button-with-html-only: -->
+    <div class="col-md-3 col-sm-3">
+      <div class="btn-group phone-ahead-toggle" data-toggle="buttons" id="btnrocker">
         <label class="btn btn-default active" id="btnrocker">
             <input type="radio" name="options" id="waitlist" width="20"><span class="glyphicon glyphicon-user"></span>
         </label>
         <label class="btn btn-default" id="btnrocker">
             <input type="radio" name="options" id="phone" width="20"><span class="glyphicon glyphicon-earphone"></span>
         </label>
+      </div>
     </div>
-</div>
-<div class="col-md-4 col-sm-3">
-
-  <div class="btn-group dropdown">
-    <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
-      Hours <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-      <li><a href="#">0</a></li>
-      <li><a href="#">1</a></li>
-      <li><a href="#">2</a></li>
-      <li><a href="#">3</a></li>
-  </ul>
-
-</div>
-<strong>:</strong>
-<div class="btn-group dropdown">
-    <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
-      Minutes <span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu">
-     <li><a href="#">00</a></li>
-     <li><a href="#">05</a></li>
-     <li><a href="#">10</a></li>
-     <li><a href="#">15</a></li>
-     <li><a href="#">20</a></li>
-     <li><a href="#">25</a></li>
-     <li><a href="#">30</a></li>
-     <li><a href="#">35</a></li>
-     <li><a href="#">40</a></li>
-     <li><a href="#">45</a></li>
-     <li><a href="#">50</a></li>
-     <li><a href="#">55</a></li>
- </ul>
-</div>
-
-<button class="btn btn-default add-party-button" type="button">ADD</button>
-
-</div>
-</div>
+    <div class="col-md-4 col-sm-3">
+      <div class="btn-group dropdown">
+        <button type="button" class="btn btn-default dropdown-toggle" id="hours-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value = "">
+          Hours <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li><a href="#">0</a></li>
+          <li><a href="#">1</a></li>
+          <li><a href="#">2</a></li>
+          <li><a href="#">3</a></li>
+        </ul>
+      </div>
+      <strong>:</strong>
+      <div class="btn-group dropdown">
+        <button type="button" class="btn btn-default dropdown-toggle" id="minutes-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" value="">
+          Minutes <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+           <li><a href="#">00</a></li>
+           <li><a href="#">05</a></li>
+           <li><a href="#">10</a></li>
+           <li><a href="#">15</a></li>
+           <li><a href="#">20</a></li>
+           <li><a href="#">25</a></li>
+           <li><a href="#">30</a></li>
+           <li><a href="#">35</a></li>
+           <li><a href="#">40</a></li>
+           <li><a href="#">45</a></li>
+           <li><a href="#">50</a></li>
+           <li><a href="#">55</a></li>
+         </ul>
+      </div>
+      <button class="btn btn-default add-party-button" type="button">ADD</button>
+    </div>
+  </div>
 </div>
 
 <!-- Responsive Table used from: http://www.w3schools.com/bootstrap/bootstrap_tables.asp -->


### PR DESCRIPTION
cc @themacexpert @michaelmachlin 

This fixes the formatting of the add party section of the waitlist page. 

Also fixes the formatting of `waitlist.html.tmpl` which had become kind of a mess. Now all the `<div>` and `</div>` are lined up nicely. 

Big screen formatting:
![screen shot 2016-11-02 at 9 38 55 pm](https://cloud.githubusercontent.com/assets/452498/19953506/e0ade7de-a144-11e6-9a2b-22b2925c7c77.png)

Small screen (ipad/iphone) formatting:
![screen shot 2016-11-02 at 9 39 18 pm](https://cloud.githubusercontent.com/assets/452498/19953509/ea1320d2-a144-11e6-8908-6905ab1f5ded.png)


